### PR TITLE
Fix HttpClient not closing after use

### DIFF
--- a/shared/src/commonMain/kotlin/codes/chrishorner/reverserainbow/data/fetcher.kt
+++ b/shared/src/commonMain/kotlin/codes/chrishorner/reverserainbow/data/fetcher.kt
@@ -37,7 +37,10 @@ suspend fun fetchTiles(
   val url = "$ApiEndpoint$year-$month-$day.json"
 
   return try {
-    HttpClient(httpEngine).get(url).toResult()
+    // We generally only make one request, then we never need an HttpClient again. If we need to
+    // retry then we pay the price of instantiating a new client object every time - no biggy in an
+    // app of this size.
+    HttpClient(httpEngine).use { it.get(url).toResult() }
   } catch (e: Exception) {
     logging("Reverse Rainbow").e(e) { "Failed to fetch tiles." }
     TileFetchResult.NetworkFailure


### PR DESCRIPTION
We spin up a new one of these every request. Not a huge deal since we generally only make one request, but given we're OK with that approach it should really be closed after each use.